### PR TITLE
Migrate to `jo` for json creation in shell

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,12 @@
 FROM elixir:1.9.4-alpine as builder
 
 # Install SSL ca certificates
-RUN apk update && apk add ca-certificates && apk add bash
+RUN apk update && apk add ca-certificates bash
+RUN apk add \
+  --no-cache \
+  --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing \
+  --repository http://dl-cdn.alpinelinux.org/alpine/edge/main \
+  jo
 
 # Create appuser
 RUN adduser -D -g '' appuser

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,11 @@
 FROM elixir:1.9.4-alpine as builder
 
-# Install SSL ca certificates
+# Install SSL ca certificates and bash
 RUN apk update && apk add ca-certificates bash
+
+# Install `jo` from the edge repository
+# `jo` is not avalable in the standard branch, so it requires an overlay
+# TODO: When `jo` is available in the main branch, consider removing this overlay
 RUN apk add \
   --no-cache \
   --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing \

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -38,8 +38,7 @@ compile_step=$(MIX_ENV=test mix compile)
 
 # On compilation error, create results.json with compile error, halt script with error
 if [ $? -ne 0 ]; then
-  compile_step=$(printf "${compile_step}" | tr '"' '`')
-  printf '{"status": "fail", "message": "%q", "tests": []}\n' "${compile_step}" | sed -e 's/\("\$\x27\)\|\(\x27"\)/"/g' > "${output_dir}/results.json"
+  jo status=fail message="${compile_step}" tests="[]" > "${output_dir}/results.json"
   printf "Compilation contained error, see ${output_dir}/results.json\n"
   exit 1
 fi


### PR DESCRIPTION
Dockerfile change to add jo from edge repository.

run.sh to change compile step failure from `printf` json creation
to `jo` json creation.

Local testing and local docker image testing passing

---

@ccare please review re: dockerfile change