### PR TITLE
Migrate to Ubuntu-slim image for docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,11 @@
-FROM elixir:1.10-alpine
+FROM elixir:1.10.4-slim
 
 # Install SSL ca certificates
-RUN apk update && \
-  apk add ca-certificates && \
-  apk add curl && \
-  apk add bash
+RUN apt-get update && \
+  apt-get install curl bash jo -y
 
 # Create appuser
-RUN adduser -D -g '' appuser
-
-# Install `jo` from the edge repository
-# `jo` is not avalable in the standard branch, so it requires an overlay
-# TODO: When `jo` is available in the main branch, consider removing this overlay
-RUN apk add \
-  --no-cache \
-  --repository http://dl-cdn.alpinelinux.org/alpine/edge/community \
-  jo
+RUN useradd -ms /bin/bash appuser
 
 # Get exercism's tooling_webserver
 RUN curl -L -o /usr/local/bin/tooling_webserver \

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -40,7 +40,7 @@ compile_step=$(MIX_ENV=test mix compile)
 if [ $? -ne 0 ]; then
   jo status=fail message="${compile_step}" tests="[]" > "${output_dir}/results.json"
   printf "Compilation contained error, see ${output_dir}/results.json\n"
-  exit 1
+  exit 0
 fi
 
 # Move JSONFormatter and Jason beam files to submission

--- a/exercism_formatter/lib/exercism_formatter/cli.ex
+++ b/exercism_formatter/lib/exercism_formatter/cli.ex
@@ -2,22 +2,24 @@ defmodule ExercismFormatter.CLI do
   @moduledoc false
 
   @usage """
-    Usage:
-    > exercism_formatter [--transform <filename> [--replace]]
-    > exercism_formatter [--log-to-json <log filename>]
-    > exercism_formatter [--combine <result json>:<log json>]
-    """
+  Usage:
+  > exercism_formatter [--transform <filename> [--replace]]
+  > exercism_formatter [--log-to-json <log filename>]
+  > exercism_formatter [--combine <result json>:<log json>]
+  """
 
   @spec main() :: no_return
   @spec main(list(String.t())) :: no_return
   def main(args \\ []) do
     {argv, _, _} =
-      OptionParser.parse(args, strict: [
-        transform: :string,
-        replace: :boolean,
-        log_to_json: :string,
-        combine: :string
-      ])
+      OptionParser.parse(args,
+        strict: [
+          transform: :string,
+          replace: :boolean,
+          log_to_json: :string,
+          combine: :string
+        ]
+      )
 
     cond do
       argv[:transform] ->
@@ -27,7 +29,7 @@ defmodule ExercismFormatter.CLI do
         log_to_json(argv[:log_to_json])
 
       argv[:combine] ->
-        [result, log] = argv[:combine] |> IO.inspect(label: "30") |> String.split(":") |> IO.inspect(label: "30")
+        [result, log] = argv[:combine] |> String.split(":")
 
         combine(result, log)
 
@@ -43,7 +45,7 @@ defmodule ExercismFormatter.CLI do
       else
         path = Path.dirname(file)
         name = Path.basename(file, ".exs")
-        Path.join(path, (name <> "_transformed.exs"))
+        Path.join(path, name <> "_transformed.exs")
       end
 
     transformed =
@@ -93,6 +95,7 @@ defmodule ExercismFormatter.CLI do
     cond do
       log[name] ->
         output = log[name]
+
         output =
           cond do
             String.length(output) > 500 -> String.slice(output, -3..-1) <> "..."
@@ -101,7 +104,8 @@ defmodule ExercismFormatter.CLI do
 
         Map.put(test, "output", output)
 
-      true -> test
+      true ->
+        test
     end
   end
 end

--- a/exercism_formatter/lib/json_formatter.ex
+++ b/exercism_formatter/lib/json_formatter.ex
@@ -28,9 +28,9 @@ defmodule JSONFormatter do
       skipped_counter: 0,
       excluded_counter: 0,
       invalid_counter: 0,
-
       results: %{
-        status: :pass, # or :fail, or :error
+        # or :fail, or :error
+        status: :pass,
         message: nil,
         tests: [
           # {
@@ -55,7 +55,7 @@ defmodule JSONFormatter do
 
     file_name = get_report_file_path()
 
-    :ok = File.write(file_name, json_results, [:write])
+    :ok = File.write(file_name, json_results)
 
     if System.get_env("JSON_PRINT_FILE") do
       IO.puts(:stderr, "Wrote JSON report to: #{file_name}")
@@ -87,7 +87,12 @@ defmodule JSONFormatter do
     status = update_result_status(config.results.status, :fail)
     results = %{config.results | status: status, tests: [test | config.results.tests]}
 
-    config = %{config | test_counter: test_counter, excluded_counter: config.excluded_counter + 1, results: results}
+    config = %{
+      config
+      | test_counter: test_counter,
+        excluded_counter: config.excluded_counter + 1,
+        results: results
+    }
 
     {:noreply, config}
   end
@@ -99,7 +104,12 @@ defmodule JSONFormatter do
     status = update_result_status(config.results.status, :fail)
     results = %{config.results | status: status, tests: [test | config.results.tests]}
 
-    config = %{config | test_counter: test_counter, skipped_counter: config.skipped_counter + 1, results: results}
+    config = %{
+      config
+      | test_counter: test_counter,
+        skipped_counter: config.skipped_counter + 1,
+        results: results
+    }
 
     {:noreply, config}
   end
@@ -111,7 +121,12 @@ defmodule JSONFormatter do
     status = update_result_status(config.results.status, :error)
     results = %{config.results | status: status, tests: [test | config.results.tests]}
 
-    config = %{config | test_counter: test_counter, invalid_counter: config.invalid_counter + 1, results: results}
+    config = %{
+      config
+      | test_counter: test_counter,
+        invalid_counter: config.invalid_counter + 1,
+        results: results
+    }
 
     {:noreply, config}
   end


### PR DESCRIPTION
see https://github.com/exercism/elixir-test-runner/commit/071613555c6f8b0587504d19e271e1f9559aad4c -- in short: interesting phenomenon was occuring with alpine image. When set to `--network none` with docker, elixir takes a very long time to load.  This is very quick when the network is not restricted for some reason.  This also doesn't seem to be *as bad* of an issue with an ubuntu-slim image.  It is slow_er_ but not slow.

This PR is mostly a lateral move to an ubuntu-slim image