### PR TITLE
Use correct field name for test code

### DIFF
--- a/exercism_test_helper/lib/exercism_test_helper/cli/command/combine_json.ex
+++ b/exercism_test_helper/lib/exercism_test_helper/cli/command/combine_json.ex
@@ -32,7 +32,7 @@ defmodule ExercismTestHelper.CLI.Command.CombineJSON do
             add_metadata_error_fields(test)
 
           true ->
-            Map.put(test, "test_body", test_metadata["test_body"])
+            Map.put(test, "test_code", test_metadata["test_code"])
         end
 
       true ->
@@ -66,7 +66,7 @@ defmodule ExercismTestHelper.CLI.Command.CombineJSON do
 
   defp add_metadata_error_fields(test, reason \\ "metadata unavailable") do
     test
-    |> Map.put("test_body", nil)
+    |> Map.put("test_code", nil)
     |> Map.put("metadata-error", reason)
   end
 end

--- a/exercism_test_helper/lib/meta/test_parser/test.ex
+++ b/exercism_test_helper/lib/meta/test_parser/test.ex
@@ -1,15 +1,15 @@
 defmodule Meta.TestParser.Test do
-  @derive {Jason.Encoder, only: [:name, :test_body]}
-  defstruct [:name, :test_body]
+  @derive {Jason.Encoder, only: [:name, :test_code]}
+  defstruct [:name, :test_code]
 
   alias Meta.TestParser.CodeBlock
 
   def make(description, name, test_block) do
-    test_body = CodeBlock.determine(test_block) |> to_string()
+    test_code = CodeBlock.determine(test_block) |> to_string()
 
     %__MODULE__{
       name: make_name(description, name),
-      test_body: test_body
+      test_code: test_code
     }
   end
 


### PR DESCRIPTION
The results.json file used test_block instead of test_code.

Note: I didn't test this locally, this was just a search and replace.