### PR TITLE
Report tests in correct order

### DIFF
--- a/exercism_test_helper/lib/json_formatter.ex
+++ b/exercism_test_helper/lib/json_formatter.ex
@@ -51,6 +51,8 @@ defmodule JSONFormatter do
 
   @impl true
   def handle_cast({:suite_finished, _run_us, _load_us}, config) do
+    # tests needs to be reported from first to last
+    config = update_in(config, [:results, :tests], &Enum.reverse/1)
     {:ok, json_results} = Jason.encode(config.results)
 
     file_name = get_report_file_path()

--- a/exercism_test_helper/test/json_formatter_test.exs
+++ b/exercism_test_helper/test/json_formatter_test.exs
@@ -97,6 +97,25 @@ defmodule JSONFormatterTest do
       assert test_name_value == "test it will pass"
       assert test_message_value == nil
     end
+
+    test "tests are reported in order" do
+      defsuite do
+        test "first test", do: assert(true)
+        test "second test", do: assert(false)
+        test "third test", do: assert(true)
+      end
+
+      output = run_and_capture_output()
+
+      {:ok, json_output} = Jason.decode(output)
+      {:ok, tests} = json_get_in(json_output, ~w{tests})
+
+      assert Enum.map(tests, & &1["name"]) == [
+               "test first test",
+               "test second test",
+               "test third test"
+             ]
+    end
   end
 
   defp run_and_capture_output(opts \\ []) do


### PR DESCRIPTION
As I was solving an exercise step-by-step, I noticed that the tests aren't run in the correct order. I would get a failing test for the last step instead of the first/next step.

<img width="1263" alt="Screen Shot 2021-01-09 at 11 15 09" src="https://user-images.githubusercontent.com/7852553/104089812-270f5e00-5272-11eb-9e70-6d32d2bf833b.png">
