### PR TITLE
Status when compilation error occurs should be "error"

### DIFF
--- a/bin/run.sh
+++ b/bin/run.sh
@@ -44,7 +44,7 @@ compile_step=$(MIX_ENV=test mix compile)
 
 # On compilation error, create results.json with compile error, halt script with error
 if [ $? -ne 0 ]; then
-  jo status=fail message="${compile_step}" tests="[]" > "${output_dir}/results.json"
+  jo status=error message="${compile_step}" tests="[]" > "${output_dir}/results.json"
   printf "Compilation contained error, see ${output_dir}/results.json\n"
   exit 0
 fi


### PR DESCRIPTION
See Slack discussion: https://exercism-team.slack.com/archives/CC3B7S3CY/p1610186200160200

Status "fail" is for tests that compiles, but assertions failed. Status "error" is for when tests couldn't compile - see https://github.com/exercism/v3-docs/blob/master/anatomy/track-tooling/test-runners/interface.md#status