### PR TITLE
Add version to results.json file

### DIFF
--- a/bin/run.sh
+++ b/bin/run.sh
@@ -44,7 +44,7 @@ compile_step=$(MIX_ENV=test mix compile)
 
 # On compilation error, create results.json with compile error, halt script with error
 if [ $? -ne 0 ]; then
-  jo status=error message="${compile_step}" tests="[]" > "${output_dir}/results.json"
+  jo version=2 status=error message="${compile_step}" tests="[]" > "${output_dir}/results.json"
   printf "Compilation contained error, see ${output_dir}/results.json\n"
   exit 0
 fi

--- a/exercism_test_helper/lib/json_formatter.ex
+++ b/exercism_test_helper/lib/json_formatter.ex
@@ -29,6 +29,7 @@ defmodule JSONFormatter do
       excluded_counter: 0,
       invalid_counter: 0,
       results: %{
+        version: 2,
         # or :fail, or :error
         status: :pass,
         message: nil,

--- a/exercism_test_helper/test/json_formatter_test.exs
+++ b/exercism_test_helper/test/json_formatter_test.exs
@@ -27,6 +27,7 @@ defmodule JSONFormatterTest do
 
       {:ok, json_output} = Jason.decode(output)
 
+      assert_json_path(json_output, ~w{version})
       assert_json_path(json_output, ~w{status})
       assert_json_path(json_output, ~w{message})
       assert_json_path(json_output, ~w{tests})


### PR DESCRIPTION
We recently introduced a `version` key to the `results.json` file. See https://github.com/exercism/docs/blob/main/building/tooling/test-runners/interface.md#version

The Elixir test runner did not yet specify the version in the `results.json` file, which meant that the website inferred it to be version 1, whereas in fact the Elixir test runner supports version 2.

This PR adds the `"version": 2` property to the `results.json` files. I found two places that needed to be updated:

1. The compile error case
1. The non-compile error case

I've tried to update the tests where appropriate, but as I don't know any Elixir, feel free to critique this PR :)
