### PR TITLE
🤖 Update `.dockerignore` file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -34,3 +34,4 @@ erl_crash.dump
 
 # Ignore package tarball (built via "mix hex.build").
 exercism_test_helper-*.tar
+.appends

--- a/.dockerignore
+++ b/.dockerignore
@@ -37,3 +37,4 @@ exercism_test_helper-*.tar
 .appends
 .gitattributes
 .dockerignore
+Dockerfile

--- a/.dockerignore
+++ b/.dockerignore
@@ -35,3 +35,4 @@ erl_crash.dump
 # Ignore package tarball (built via "mix hex.build").
 exercism_test_helper-*.tar
 .appends
+.gitattributes

--- a/.dockerignore
+++ b/.dockerignore
@@ -36,3 +36,4 @@ erl_crash.dump
 exercism_test_helper-*.tar
 .appends
 .gitattributes
+.dockerignore


### PR DESCRIPTION
To help both speedup Docker builds _and_ prevent new containers being created when unrelated files changes, this PR adds some rules to the `.dockerignore` file (or add the file when it didn't exist).
See https://docs.docker.com/engine/reference/builder/#dockerignore-file for more information on `.dockerignore` files and what they do.

# Tracking issue

See https://github.com/exercism/exercism/issues/6113
