### PR TITLE
CI: pin GitHub Actions runners

### DIFF
--- a/.github/workflows/elixir_tests.yml
+++ b/.github/workflows/elixir_tests.yml
@@ -48,7 +48,7 @@ jobs:
           ./bin/test_all_exercises.sh
 
   smoke_test_in_docker:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/exercism_test_helper_build_test.yml
+++ b/.github/workflows/exercism_test_helper_build_test.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     container:
       image: hexpm/elixir:1.15.2-erlang-26.0.2-debian-bookworm-20230612


### PR DESCRIPTION
This PR updates GitHub Actions runners to a specific version.
This ensures that the workflow will always run on the same runner, which makes your build _stable_.

The PR updates the *-latest version with the current version, as specified in https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources.

See https://exercism.org/docs/building/github/gha-best-practices#h-pin-test-runners-to-version for more information.