### PR TITLE
Revert "Revert "Update to Elixir 1.18 (#132)" (#133)"

### DIFF
--- a/.github/workflows/elixir_tests.yml
+++ b/.github/workflows/elixir_tests.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-20.04
 
     container:
-      image: hexpm/elixir:1.17.0-erlang-27.0-debian-bookworm-20240612
+      image: hexpm/elixir:1.18.0-erlang-27.2-debian-bullseye-20241202
 
     steps:
       - name: Install git

--- a/.github/workflows/elixir_tests.yml
+++ b/.github/workflows/elixir_tests.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-20.04
 
     container:
-      image: hexpm/elixir:1.18.0-erlang-27.2-debian-bullseye-20241202
+      image: hexpm/elixir:1.18.0-erlang-27.2-debian-bookworm-20241202
 
     steps:
       - name: Install git

--- a/.github/workflows/elixir_tests.yml
+++ b/.github/workflows/elixir_tests.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-20.04
 
     container:
-      image: hexpm/elixir:1.18.0-erlang-27.2-debian-bookworm-20241202
+      image: hexpm/elixir:1.18.1-erlang-27.2-debian-bookworm-20241223
 
     steps:
       - name: Install git

--- a/.github/workflows/exercism_test_helper_build_test.yml
+++ b/.github/workflows/exercism_test_helper_build_test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     container:
-      image: hexpm/elixir:1.18.0-erlang-27.2-debian-bullseye-20241202
+      image: hexpm/elixir:1.18.0-erlang-27.2-debian-bookworm-20241202
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683

--- a/.github/workflows/exercism_test_helper_build_test.yml
+++ b/.github/workflows/exercism_test_helper_build_test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     container:
-      image: hexpm/elixir:1.17.0-erlang-27.0-debian-bookworm-20240612
+      image: hexpm/elixir:1.18.0-erlang-27.2-debian-bullseye-20241202
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683

--- a/.github/workflows/exercism_test_helper_build_test.yml
+++ b/.github/workflows/exercism_test_helper_build_test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     container:
-      image: hexpm/elixir:1.18.0-erlang-27.2-debian-bookworm-20241202
+      image: hexpm/elixir:1.18.1-erlang-27.2-debian-bookworm-20241223
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.18.0-otp-27
+elixir 1.18.1-otp-27
 erlang 27.2

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.17.0-otp-27
+elixir 1.18.0-otp-27
 erlang 27.0

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 elixir 1.18.0-otp-27
-erlang 27.0
+erlang 27.2

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,15 +13,15 @@ COPY . .
 
 # Compile the formatter
 WORKDIR /opt/test-runner/exercism_test_helper
-RUN mix local.rebar --force
-RUN mix local.hex --force
-RUN mix deps.get
-RUN MIX_ENV=test mix compile
-RUN mix test --no-compile
+RUN mix local.rebar --force && \
+  mix local.hex --force && \
+  mix deps.get && \
+  MIX_ENV=test mix compile && \
+  mix test --no-compile
 
 # Build the escript
-RUN MIX_ENV=prod mix escript.build
-RUN mv exercism_test_helper /opt/test-runner/bin
+RUN MIX_ENV=prod mix escript.build && \
+  mv exercism_test_helper /opt/test-runner/bin
 
 USER appuser
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM hexpm/elixir:1.18.0-erlang-27.2-debian-bullseye-20241202
+FROM hexpm/elixir:1.18.0-erlang-27.2-debian-bookworm-20241202
 
 # Install SSL ca certificates
 RUN apt-get update && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM hexpm/elixir:1.17.0-erlang-27.0-debian-bookworm-20240612
+FROM hexpm/elixir:1.18.0-erlang-27.2-debian-bullseye-20241202
 
 # Install SSL ca certificates
 RUN apt-get update && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,9 @@ RUN mix local.rebar --force && \
 RUN MIX_ENV=prod mix escript.build && \
   mv exercism_test_helper /opt/test-runner/bin
 
+# clear temp files created by root to avoid permission issues
+RUN rm -rf /tmp/*
+
 USER appuser
 
 WORKDIR /opt/test-runner

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM hexpm/elixir:1.18.0-erlang-27.2-debian-bookworm-20241202
+FROM hexpm/elixir:1.18.1-erlang-27.2-debian-bookworm-20241223
 
 # Install SSL ca certificates
 RUN apt-get update && \

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Exercism Automated Test Runner for Elixir Exercises
 
 ## Environment
 
-The test runner currently targets exercises supporting Elixir >= 1.12 and Erlang/OTP >= 24, but is running on Elixir 1.17.0 on hexpm's `elixir:1.17.0-erlang-27.0-debian-bookworm-20240612` image.
+The test runner currently targets exercises supporting Elixir >= 1.14 and Erlang/OTP >= 25, but is running on Elixir 1.18.0 on hexpm's `elixir:1.18.0-erlang-27.2-debian-bullseye-20241202` image.
 
 The `Dockerfile` also has added `bash`, `jo` and `jq` to the image.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Exercism Automated Test Runner for Elixir Exercises
 
 ## Environment
 
-The test runner currently targets exercises supporting Elixir >= 1.14 and Erlang/OTP >= 25, but is running on Elixir 1.18.0 on hexpm's `elixir:1.18.0-erlang-27.2-debian-bookworm-20241202` image.
+The test runner currently targets exercises supporting Elixir >= 1.14 and Erlang/OTP >= 25, but is running on Elixir 1.18.0 on hexpm's `elixir:1.18.1-erlang-27.2-debian-bookworm-20241223` image.
 
 The `Dockerfile` also has added `bash`, `jo` and `jq` to the image.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Exercism Automated Test Runner for Elixir Exercises
 
 ## Environment
 
-The test runner currently targets exercises supporting Elixir >= 1.14 and Erlang/OTP >= 25, but is running on Elixir 1.18.0 on hexpm's `elixir:1.18.0-erlang-27.2-debian-bullseye-20241202` image.
+The test runner currently targets exercises supporting Elixir >= 1.14 and Erlang/OTP >= 25, but is running on Elixir 1.18.0 on hexpm's `elixir:1.18.0-erlang-27.2-debian-bookworm-20241202` image.
 
 The `Dockerfile` also has added `bash`, `jo` and `jq` to the image.
 

--- a/exercism_test_helper/mix.exs
+++ b/exercism_test_helper/mix.exs
@@ -5,7 +5,7 @@ defmodule ExercismTestHelper.MixProject do
     [
       app: :exercism_test_helper,
       version: "0.1.2",
-      elixir: "~> 1.17",
+      elixir: "~> 1.18",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       escript: escript()


### PR DESCRIPTION
Some time after pushing the 1.18 update, several students had the following issue 

```
12:47:06.474 [error] GenServer Mix.Sync.PubSub terminating
** (File.Error) could not make directory (with -p) "/tmp/mix_pubsub/P2SrvbEiUDXbwyyvCwHtmA": permission denied
    (elixir 1.18.1) lib/file.ex:346: File.mkdir_p!/1
    (mix 1.18.1) lib/mix/sync/pubsub.ex:222: Mix.Sync.PubSub.create_subscription_file/2
    (mix 1.18.1) lib/mix/sync/pubsub.ex:142: Mix.Sync.PubSub.handle_call/3
    (stdlib 6.2) gen_server.erl:2381: :gen_server.try_handle_call/4
    (stdlib 6.2) gen_server.erl:2410: :gen_server.handle_msg/6
    (stdlib 6.2) proc_lib.erl:329: :proc_lib.init_p_do_apply/3
Last message (from Mix.PubSub.Subscriber): {:subscribe, #PID<0.111.0>, "/tmp/solution_i2Nb99z1Gd/_build/test"}
State: %{port: nil, hash_to_pids: %{}}
Client Mix.PubSub.Subscriber is alive

    (stdlib 6.2) gen.erl:241: :gen.do_call/4
    (elixir 1.18.1) lib/gen_server.ex:1125: GenServer.call/3
    (mix 1.18.1) lib/mix/sync/pubsub.ex:44: Mix.Sync.PubSub.subscribe/1
    (mix 1.18.1) lib/mix/pubsub/subscriber.ex:21: Mix.PubSub.Subscriber.init/1
    (stdlib 6.2) gen_server.erl:2229: :gen_server.init_it/2
    (stdlib 6.2) gen_server.erl:2184: :gen_server.init_it/6
    (stdlib 6.2) proc_lib.erl:329: :proc_lib.init_p_do_apply/3

12:47:06.574 [notice] Application mix exited: shutdown
** (ArgumentError) errors were found at the given arguments:

  * 1st argument: the table identifier does not refer to an existing ETS table

    (stdlib 6.2) :ets.lookup(Mix.State, :debug)
    (mix 1.18.1) lib/mix/state.ex:26: Mix.State.get/2
    (mix 1.18.1) lib/mix/cli.ex:112: Mix.CLI.run_task/2
```

I believe that this is because when we build the project using `mix`, the `/tmp/mix_pubsub` folder is created. But since the build is created by `root`, `appuser` will later be unable to modify it.
I modified the build to clear `/tmp` before passing over to `appuser` and it worked locally for me.

What this PR is missing is a good explanation of why this wasn't detected before and a new test to prevent similar issues.
When I used `bin/run-in-docker.sh slug /path/to/exercise .`, it all worked fine. I could only reproduce the issue by using the docker container interactively with `docker run -it --entrypoint /bin/bash exercism/elixir-test-runner` and running `bin/run.sh slug /opt/test-runner/test/hello-world/ /tmp`.
Suggestions welcome.